### PR TITLE
Add instruction to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,6 @@ The backend is built with Ruby on Rails while the frontend is built with React.
 ``bin/rails server``
 
 ### Frontend
+``cd frontend/``
 ``npm install``
 ``npm start``


### PR DESCRIPTION
Why:
  * Information on how to run the frontend was missing
  
How: 
  * Added "cd frontend/" to guarantee the user knows they have to run the frontend from that directory