### PR TITLE
Absolute imports

### DIFF
--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src"
+  },
+  "include": ["src"]
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,12 +1,13 @@
 import { Routes, Route } from "react-router-dom";
 import "./App.css";
 
-import HomePage from "./pages/HomePage";
-import MainHeader from "./components/MainHeader";
-import PrizePage from "./pages/PrizePage";
-import SignupPage from "./pages/SignupPage";
-import SocialPage from "./pages/SocialPage";
-import WheelPage from "./pages/WheelPage";
+import MainHeader from "components/MainHeader";
+
+import HomePage from "pages/HomePage";
+import PrizePage from "pages/PrizePage";
+import SignupPage from "pages/SignupPage";
+import SocialPage from "pages/SocialPage";
+import WheelPage from "pages/WheelPage";
 
 function App() {
   return (

--- a/frontend/src/components/Prize/index.js
+++ b/frontend/src/components/Prize/index.js
@@ -1,13 +1,14 @@
 import { PropTypes } from "prop-types";
+
+import Button from "components/Button";
+import Text from "components/Typography/Text";
+import Title from "components/Typography/Title";
+
 import styles from "./index.module.css";
 
-import Title from "../Typography/Title";
-import Text from "../Typography/Text";
-import Button from "../Button";
-
 // Prizes
-import Tshit from "../../assets/imgs/prizes/tshirt.png";
-import NFT from "../../assets/imgs/prizes/nft.png";
+import Tshit from "assets/imgs/prizes/tshirt.png";
+import NFT from "assets/imgs/prizes/nft.png";
 
 const Prize = (props) => {
   let prizeName = "";

--- a/frontend/src/components/SocialMediaButton/index.js
+++ b/frontend/src/components/SocialMediaButton/index.js
@@ -1,13 +1,13 @@
 import styles from "./index.module.css";
 
-import Github from "../../assets/imgs/socialButtons/github.png";
-import LinkedIn from "../../assets/imgs/socialButtons/linkedin.png";
-import Behance from "../../assets/imgs/socialButtons/behance.png";
-import Facebook from "../../assets/imgs/socialButtons/facebook.png";
-import Instagram from "../../assets/imgs/socialButtons/instagram.png";
-import Dribbble from "../../assets/imgs/socialButtons/dribble.png";
-import Medium from "../../assets/imgs/socialButtons/medium.png";
-import Twitter from "../../assets/imgs/socialButtons/twitter.png";
+import Github from "assets/imgs/socialButtons/github.png";
+import LinkedIn from "assets/imgs/socialButtons/linkedin.png";
+import Behance from "assets/imgs/socialButtons/behance.png";
+import Facebook from "assets/imgs/socialButtons/facebook.png";
+import Instagram from "assets/imgs/socialButtons/instagram.png";
+import Dribbble from "assets/imgs/socialButtons/dribble.png";
+import Medium from "assets/imgs/socialButtons/medium.png";
+import Twitter from "assets/imgs/socialButtons/twitter.png";
 
 const socialMediaButton = (props) => {
   const name = props.name;

--- a/frontend/src/pages/HomePage/index.js
+++ b/frontend/src/pages/HomePage/index.js
@@ -1,10 +1,9 @@
-// Components
-import Header from "../../components/Header";
-import Title from "../../components/Typography/Title";
-import Text from "../../components/Typography/Text";
-import Button from "../../components/Button";
-import ellipse1 from "../../assets/imgs/ellipses/Ellipse1.svg";
+import Button from "components/Button";
+import Header from "components/Header";
+import Text from "components/Typography/Text";
+import Title from "components/Typography/Title";
 
+import ellipse1 from "assets/imgs/ellipses/Ellipse1.svg";
 import styles from "./index.module.css";
 
 const HomePage = () => {

--- a/frontend/src/pages/PrizePage/index.js
+++ b/frontend/src/pages/PrizePage/index.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import Prize from "../../components/Prize";
+import Prize from "components/Prize";
 
 import styles from "./index.module.css";
 

--- a/frontend/src/pages/SignupPage/index.js
+++ b/frontend/src/pages/SignupPage/index.js
@@ -1,7 +1,7 @@
-import Header from "../../components/Header";
-import Title from "../../components/Typography/Title";
-import SocialMediaButton from "../../components/SocialMediaButton";
-import Button from "../../components/Button";
+import Button from "components/Button";
+import Header from "components/Header";
+import SocialMediaButton from "components/SocialMediaButton";
+import Title from "components/Typography/Title";
 
 import styles from "./index.module.css";
 

--- a/frontend/src/pages/SocialPage/index.js
+++ b/frontend/src/pages/SocialPage/index.js
@@ -1,10 +1,9 @@
-import styles from "./index.module.css";
+import Header from "components/Header";
+import SocialMediaButton from "components/SocialMediaButton";
+import Text from "components/Typography/Text";
+import Title from "components/Typography/Title";
 
-// Components
-import Header from "../../components/Header";
-import Title from "../../components/Typography/Title";
-import Text from "../../components/Typography/Text";
-import SocialMediaButton from "../../components/SocialMediaButton";
+import styles from "./index.module.css";
 
 const SocialPage = () => {
   const site = "https://subvisual.com";


### PR DESCRIPTION
Why:

To make the imports cleaner.

How:

- Configuring a `jsconfig.json` file to import modules using absolute paths, starting from `src`
- Change all imports to use absolute paths

Also see [Absolute Imports](https://create-react-app.dev/docs/importing-a-component/#absolute-imports)

Now instead of:

```
"../../assets/imgs/socialButtons/github.png";
"./pages/WheelPage";
"../../components/Header";
```

We can do:
```
"assets/imgs/socialButtons/github.png";
"pages/WheelPage";
"components/Header";
```
