### PR TITLE
Add lead table and migrations

### DIFF
--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -1,0 +1,3 @@
+class Lead < ApplicationRecord
+    validates :name, :email, :interests, presence: true
+end

--- a/db/migrate/20220801211035_create_leads.rb
+++ b/db/migrate/20220801211035_create_leads.rb
@@ -1,0 +1,13 @@
+class CreateLeads < ActiveRecord::Migration[7.0]
+  def change
+    create_table :leads do |t|
+      t.string :name
+      t.string :email, unique: true
+      t.string :interests
+      t.boolean :data_proc_consent, default: false
+      t.boolean :delivered, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220801213725_add_prize_to_lead.rb
+++ b/db/migrate/20220801213725_add_prize_to_lead.rb
@@ -1,0 +1,5 @@
+class AddPrizeToLead < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :leads, :prizes, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_18_133933) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_01_213725) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "leads", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "interests"
+    t.boolean "data_proc_consent", default: false
+    t.boolean "delivered", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "prizes_id"
+    t.index ["prizes_id"], name: "index_leads_on_prizes_id"
+  end
 
   create_table "prizes", force: :cascade do |t|
     t.string "name"
     t.integer "percentage"
     t.string "image"
-    t.boolean "is_merch", default: false
+    t.boolean "is_token_based"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "leads", "prizes", column: "prizes_id"
 end


### PR DESCRIPTION
Why:
* For our app, we will need to store user data
* We want to associate each lead to a prize they have won, after they have played

How:
* By creating a Lead model that validates the presence of the mandatory values
* By creating a migration that creates a lead
* By creating a migration that adds a column that represents a key that matches the prize the person has won (it's null until they have played) - consulted https://guides.rubyonrails.org/active_record_migrations.html#foreign-keys