### PR TITLE
Update README.md info

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,32 @@ The backend is built with Ruby on Rails while the frontend is built with React.
 - Rails - 7.0.3
 - ProgreSQL - 14.3
 - React - 18.2.0
-- CORS - [insert version]
+- CORS
 - asdf - 0.9.0
+- MailCatcher
 
 ## How to run
 
 ### Backend
 
+The backend is hosted in https://subvisuwheel.herokuapp.com/. However it can be run locally by:
+
 `asdf install`
 `bundle install`
 `bin/rails server`
 
-### Frontend
+### Local frontend
+
+Currently the frontend is hosted in https://subvisuwheel.netlify.app/. To run locally:
 
 `cd frontend/`
 `npm install`
 `npm start`
+
+### MailCatcher
+
+`gem install mailcatcher` 
+`mailcatcher`
 
 ### Eslint, Prettier and Rubocop 
 


### PR DESCRIPTION
Why:
* Wasn't updated in a while. Didn't have the information about where the backend and frontend are now being hosted and didn't include information about the new mail service that will be used in the future. MailCatcher shouldn't be placed in Gemfile according to the documentation so it should tell the user that they have to handle that themselves and how to do that.

How:
* By adding the links to the backend and frontend
* By adding the steps to install and run MailCatcher