### PR TITLE
Change font-size to size variables

### DIFF
--- a/frontend/src/components/Button/index.module.css
+++ b/frontend/src/components/Button/index.module.css
@@ -2,7 +2,7 @@
   min-width: 335px;
   padding: 20px;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-xs);
+  font-size: var(--size-xs);
   font-weight: 600;
   line-height: 20px;
   color: var(--color-blue);

--- a/frontend/src/components/Typography/Body/index.module.css
+++ b/frontend/src/components/Typography/Body/index.module.css
@@ -1,6 +1,6 @@
 .body {
   font-family: var(--font-family-body);
-  font-size: var(--font-size-xs);
+  font-size: var(--size-xs);
   font-weight: 400;
   line-height: 20px;
 }

--- a/frontend/src/components/Typography/Heading1/index.module.css
+++ b/frontend/src/components/Typography/Heading1/index.module.css
@@ -1,6 +1,6 @@
 .heading1 {
   font-family: var(--font-family-body);
-  font-size: var(--font-size-lg);
+  font-size: var(--size-lg);
   font-weight: 500;
   line-height: 40px;
   color: var(--color-black);

--- a/frontend/src/components/Typography/Heading2/index.module.css
+++ b/frontend/src/components/Typography/Heading2/index.module.css
@@ -1,6 +1,6 @@
 .heading2 {
   font-family: var(--font-family-body);
-  font-size: var(--font-size-md);
+  font-size: var(--size-md);
   font-weight: 500;
   line-height: 32px;
   color: var(--color-black);

--- a/frontend/src/components/Typography/Heading3/index.module.css
+++ b/frontend/src/components/Typography/Heading3/index.module.css
@@ -1,6 +1,6 @@
 .heading3 {
   font-family: var(--font-family-body);
-  font-size: var(--font-size-sm);
+  font-size: var(--size-sm);
   font-weight: 400;
   line-height: 24px;
   color: var(--color-black);

--- a/frontend/src/components/Typography/Logo/index.module.css
+++ b/frontend/src/components/Typography/Logo/index.module.css
@@ -1,6 +1,6 @@
 .logo {
   font-family: var(--font-family-title);
-  font-size: var(--font-size-xl);
+  font-size: var(--size-xl);
   font-weight: 400;
   line-height: 48px;
   color: var(--color-black);

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -15,9 +15,9 @@
   --color-white: #fff;
   --font-family-body: "Work Sans", sans-serif;
   --font-family-title: "Spicy Rice", cursive;
-  --font-size-xs: 16px;
-  --font-size-sm: 20px;
-  --font-size-md: 24px;
-  --font-size-lg: 32px;
-  --font-size-xl: 40px;
+  --size-xs: 16px;
+  --size-sm: 20px;
+  --size-md: 24px;
+  --size-lg: 32px;
+  --size-xl: 40px;
 }


### PR DESCRIPTION
Why:
* https://3.basecamp.com/4319812/buckets/26581088/todos/5192574897
* We were using `font-size` prefix for the sizings but we should change them to be more generic. 

How
* Use the prefix `size` (ie: `size-xs` instead of `font-size-xs`).