### PR TITLE
Fix connection between user info form and privacy policy

### DIFF
--- a/frontend/src/pages/PolicyPage/index.js
+++ b/frontend/src/pages/PolicyPage/index.js
@@ -9,9 +9,13 @@ import { useState } from "react";
 import styles from "./index.module.css";
 
 const PolicyPage = () => {
-  const [, setIsChecked] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
 
-  const handleSubmit = ({ name, email, interests, consent }) => {
+  const handleSubmit = () => {
+    const { name, email, interests } = JSON.parse(
+      localStorage.getItem("userData")
+    );
+
     fetch(`${process.env.REACT_APP_BACKEND_PATH}/leads`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -20,7 +24,7 @@ const PolicyPage = () => {
           name,
           email,
           interests,
-          consent,
+          data_proc_consent: isChecked,
         },
       }),
     }).then((response) => {

--- a/frontend/src/pages/SignupPage/index.js
+++ b/frontend/src/pages/SignupPage/index.js
@@ -34,6 +34,17 @@ const SignupPage = () => {
     ) {
       setError({ hasError: true, message: "Select at least one option" });
     } else if (step === STEP_3) {
+      if (addedInterest) {
+        selectedInterests.push(addedInterest);
+      }
+      localStorage.setItem(
+        "userData",
+        JSON.stringify({
+          name,
+          email,
+          interests: selectedInterests,
+        })
+      );
       navigator("/policy");
     } else {
       setStep((prev) => {


### PR DESCRIPTION
Why:
* The form information filled out by the user (that includes name, email and interests) wasn't being carried over to the privacy policy. So the POST request was filled with undefined values

How:
* By using local storage to carry over an object that includes that data