### PR TITLE
Change interests type from string to array

### DIFF
--- a/app/controllers/leads_controller.rb
+++ b/app/controllers/leads_controller.rb
@@ -12,6 +12,6 @@ class LeadsController < ApiController
   end
 
   def leads_params
-    params.require(:lead).permit(:name, :email, :interests, :data_proc_consent)
+    params.require(:lead).permit(:name, :email, [interests: []], :data_proc_consent)
   end
 end

--- a/db/migrate/20220810121719_change_interests_type.rb
+++ b/db/migrate/20220810121719_change_interests_type.rb
@@ -1,0 +1,6 @@
+class ChangeInterestsType < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :leads, :interests, :string
+    add_column :leads, :interests, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,12 +43,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_05_102451) do
   create_table "leads", force: :cascade do |t|
     t.string "name"
     t.string "email"
+<<<<<<< Updated upstream
     t.string "interests"
+=======
+>>>>>>> Stashed changes
     t.boolean "data_proc_consent", default: false
     t.boolean "delivered", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "prize_id"
+    t.string "interests", default: [], array: true
     t.index ["prize_id"], name: "index_leads_on_prize_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_05_102451) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_10_121719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,10 +43,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_05_102451) do
   create_table "leads", force: :cascade do |t|
     t.string "name"
     t.string "email"
-<<<<<<< Updated upstream
-    t.string "interests"
-=======
->>>>>>> Stashed changes
     t.boolean "data_proc_consent", default: false
     t.boolean "delivered", default: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
Why:
* We need to allow for it to be possible to store multiple interests for a lead

How:
* By adding a migration that removes the previous interests column with a string type and replacing it with a column with the same name but with the array type
* By changing the params to fit this 