### PR TITLE
Fix button overflow on smaller screens

### DIFF
--- a/frontend/src/components/Button/index.module.scss
+++ b/frontend/src/components/Button/index.module.scss
@@ -1,5 +1,6 @@
 .button {
-  min-width: 335px;
+  width: 100%;
+  max-width: 335px;
   padding: 20px;
   font-family: var(--font-family-body);
   font-size: var(--font-size-xs);


### PR DESCRIPTION
Why:
* Button was overflowing in smaller screens.

How:
* Used `width: 100%` and replaced `min-width` for `max-width`.