### PR TITLE
Adapt disabled button to match design

### DIFF
--- a/frontend/src/components/Button/index.module.scss
+++ b/frontend/src/components/Button/index.module.scss
@@ -17,7 +17,6 @@
   box-shadow: 0 4px 3px var(--color-gray);
 
   &:disabled {
-    color: var(--color-dark-gray);
-    background-color: var(--color-light-gray);
+    opacity: 0.4;
   }
 }


### PR DESCRIPTION
Why:
* It was discussed that the disabled button was looking too harsh on the page.

How:
* Replaced `button:disabled`'s `color` and `background-color` with a lower `opacity` value.