### PR TITLE
Block GET Leads route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,5 @@ Rails.application.routes.draw do
   get '/prizes', to: 'prizes#index'
   post '/prizes', to: 'prizes#create'
   post '/win-prize', to: 'prizes#win_prize'
-  get '/leads', to: 'leads#index'
   post '/leads', to: 'leads#create'
 end


### PR DESCRIPTION
Why:
* https://3.basecamp.com/4319812/buckets/26581088/todos/5225150075

How:
* Deleting the GET Leads route