### PR TITLE
Fix size of input hidden behind the custom checkbox

### DIFF
--- a/frontend/src/components/Checkbox/index.module.css
+++ b/frontend/src/components/Checkbox/index.module.css
@@ -12,6 +12,8 @@
 
 .input {
   position: absolute;
+  width: var(--size-checkbox);
+  height: var(--size-checkbox);
   opacity: 0;
 }
 


### PR DESCRIPTION
Why:
* It was too small so it didn't overlap the whole box and it was possible to click in most of the box without having any effect
![image](https://user-images.githubusercontent.com/62039765/184939078-05c7e593-8456-499f-9580-1d78640dcbd8.png) 
(Colors don't reflect the actual colors since I'm using dark mode)

How:
* By setting width and height for the input that match the control box