### PR TITLE
Adapt sign up to design

### DIFF
--- a/frontend/src/components/BackLink/index.module.scss
+++ b/frontend/src/components/BackLink/index.module.scss
@@ -1,5 +1,5 @@
 .buttonWrapper {
-  margin: 24px 0 76px 24px;
+  margin: 24px 0 76px;
 }
 
 .button {

--- a/frontend/src/components/BackLink/index.module.scss
+++ b/frontend/src/components/BackLink/index.module.scss
@@ -1,5 +1,5 @@
 .buttonWrapper {
-  margin: 24px 0 44px 24px;
+  margin: 24px 0 76px 24px;
 }
 
 .button {

--- a/frontend/src/components/BackLink/index.module.scss
+++ b/frontend/src/components/BackLink/index.module.scss
@@ -1,5 +1,5 @@
 .buttonWrapper {
-  margin: 24px 0 24px 24px;
+  margin: 24px 0 44px 24px;
 }
 
 .button {

--- a/frontend/src/components/Button/index.module.scss
+++ b/frontend/src/components/Button/index.module.scss
@@ -15,6 +15,7 @@
   border: none;
   border-radius: 300px;
   box-shadow: 0 4px 3px var(--color-gray);
+  transition: opacity 0.3s ease-in-out;
 }
 
 .disabled {

--- a/frontend/src/components/Forms/EmailForm/index.js
+++ b/frontend/src/components/Forms/EmailForm/index.js
@@ -5,10 +5,7 @@ import FormLayout from "components/Forms/FormLayout";
 
 function EmailForm({ email, error, handleChange }) {
   return (
-    <FormLayout
-      headerText="This won't take long."
-      promptText="How can we reach you?"
-    >
+    <FormLayout headerText="How can we reach you?">
       <Input
         id="email"
         type="email"

--- a/frontend/src/components/Forms/FormLayout/index.js
+++ b/frontend/src/components/Forms/FormLayout/index.js
@@ -1,17 +1,13 @@
 import { PropTypes } from "prop-types";
-import Heading2 from "components/Typography/Heading2";
-import Heading3 from "components/Typography/Heading3";
+import Heading1 from "components/Typography/Heading1";
 
 import styles from "./index.module.css";
 
-const FormLayout = ({ children, headerText, promptText }) => {
+const FormLayout = ({ children, headerText }) => {
   return (
     <>
       <div className={styles.headerWrapper}>
-        <Heading2>{headerText}</Heading2>
-      </div>
-      <div className={styles.promptWrapper}>
-        <Heading3>{promptText}</Heading3>
+        <Heading1>{headerText}</Heading1>
       </div>
       {children}
     </>
@@ -21,7 +17,6 @@ const FormLayout = ({ children, headerText, promptText }) => {
 FormLayout.propTypes = {
   children: PropTypes.element.isRequired,
   headerText: PropTypes.string.isRequired,
-  promptText: PropTypes.string.isRequired,
 };
 
 export default FormLayout;

--- a/frontend/src/components/Forms/FormLayout/index.module.css
+++ b/frontend/src/components/Forms/FormLayout/index.module.css
@@ -1,7 +1,4 @@
 .headerWrapper {
   margin-bottom: 48px;
-}
-
-.promptWrapper {
-  margin-bottom: 24px;
+  text-align: center;
 }

--- a/frontend/src/components/Forms/FormLayout/index.module.css
+++ b/frontend/src/components/Forms/FormLayout/index.module.css
@@ -1,4 +1,5 @@
 .headerWrapper {
+  padding: 0 20px;
   margin-bottom: 48px;
   text-align: center;
 }

--- a/frontend/src/components/Forms/InterestsForm/index.js
+++ b/frontend/src/components/Forms/InterestsForm/index.js
@@ -8,10 +8,7 @@ import styles from "./index.module.css";
 
 const InterestsForm = ({ handleChange, extraInterest, inputHidden, error }) => {
   return (
-    <FormLayout
-      headerText="Last thing!"
-      promptText="Pick one or more interests:"
-    >
+    <FormLayout headerText="What are you most interested in?">
       <>
         <div className={styles.selectedInterestsWrapper}>
           <Checkbox

--- a/frontend/src/components/Forms/NameForm/index.js
+++ b/frontend/src/components/Forms/NameForm/index.js
@@ -5,10 +5,7 @@ import Input from "components/Input";
 
 const NameForm = ({ error, handleChange, name }) => {
   return (
-    <FormLayout
-      headerText="Just a few questions..."
-      promptText="What's your name?"
-    >
+    <FormLayout headerText="What's your name?">
       <Input
         id="name"
         type="text"

--- a/frontend/src/components/Forms/PolicyForm/index.js
+++ b/frontend/src/components/Forms/PolicyForm/index.js
@@ -7,7 +7,7 @@ import styles from "./index.module.scss";
 
 const PolicyForm = ({ handleChange }) => {
   return (
-    <>
+    <div className={styles.root}>
       <div className={styles.headingWrapper}>
         <Heading1>Privacy is important to us.</Heading1>
       </div>
@@ -20,7 +20,7 @@ const PolicyForm = ({ handleChange }) => {
           >
             &nbsp;
             <a href="https://www.google.com" target="_blank" rel="noreferrer">
-              Terms and Conditions
+              Terms and Conditions*
             </a>
           </Checkbox>
         </div>
@@ -30,7 +30,7 @@ const PolicyForm = ({ handleChange }) => {
           onChange={handleChange("consent")}
         />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/frontend/src/components/Forms/PolicyForm/index.module.scss
+++ b/frontend/src/components/Forms/PolicyForm/index.module.scss
@@ -1,3 +1,7 @@
+.root {
+  padding: 0 20px;
+}
+
 .headingWrapper {
   margin-bottom: 104px;
   text-align: center;
@@ -7,7 +11,6 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 0 20px;
 }
 
 .termsAndConditions {

--- a/frontend/src/components/Input/index.module.css
+++ b/frontend/src/components/Input/index.module.css
@@ -7,6 +7,7 @@
 }
 
 .input {
+  width: 100%;
   padding: 20px 24px;
   font-family: var(--font-family-body);
   font-size: var(--font-size-xs);

--- a/frontend/src/components/MainContainer/index.module.scss
+++ b/frontend/src/components/MainContainer/index.module.scss
@@ -7,5 +7,6 @@
 }
 
 .hasGradient {
+  padding: 0;
   background: linear-gradient(var(--color-light-pink), var(--color-white));
 }

--- a/frontend/src/components/MainContainer/index.module.scss
+++ b/frontend/src/components/MainContainer/index.module.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  padding-bottom: 60px;
+  padding: 0 20px 60px;
   background-color: var(--color-faded-white);
 }
 

--- a/frontend/src/pages/SignupPage/index.js
+++ b/frontend/src/pages/SignupPage/index.js
@@ -215,9 +215,6 @@ const SignupPage = () => {
         <BackLink handleGoBack={returnToPrevStep} />
       </div>
       <div className={styles.main}>
-        <div className={styles.logo}>
-          <Logo />
-        </div>
         <div className={styles.component}>{stepInfo[state.step].component}</div>
       </div>
       <div className={styles.buttonWrapper}>

--- a/frontend/src/pages/SignupPage/index.js
+++ b/frontend/src/pages/SignupPage/index.js
@@ -5,7 +5,6 @@ import MainContainer from "components/MainContainer";
 import NameForm from "components/Forms/NameForm";
 import EmailForm from "components/Forms/EmailForm";
 import InterestsForm from "components/Forms/InterestsForm";
-import Logo from "components/Logo";
 import Button from "components/Button";
 import PolicyForm from "components/Forms/PolicyForm";
 import BackLink from "components/BackLink";
@@ -219,7 +218,11 @@ const SignupPage = () => {
       </div>
       <div className={styles.buttonWrapper}>
         <Button
-          isDisabled={state.step === STEP_4 && !state.termsChecked}
+          isDisabled={
+            (state.step === STEP_1 && state.name === "") ||
+            (state.step === STEP_2 && state.email === "") ||
+            (state.step === STEP_4 && !state.termsChecked)
+          }
           onClick={buttonHandler}
         >
           {stepInfo[state.step].buttonText}


### PR DESCRIPTION
Why:
* Sign-up flow was not updated with the new design.

How:
* Removed `Logo` from most pages since it is not present in the design;
* Fixed copy to match Figma;
* Fixed some minor details in the privacy policy section;
* Added the disabled state to the `button` when no `input` is provided in the first and second steps of the sign-up;
* Moved the side `padding` to the `MainContainer` and removed it on the pages that are using `.hasGradient`.