### PR TITLE
Remove selected attribute from being mandatory in company model

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -4,7 +4,7 @@
 class Company < ApplicationRecord
   before_save :ensure_only_one_selected
 
-  validates :name, :website, :selected, presence: true
+  validates :name, :website, presence: true
 
   has_many :socials
 


### PR DESCRIPTION
Why:
* It wouldn't let the admin add a company without forcing them to select it (mark it as the company to use)

How:
* Removed from validation presence :true