### PR TITLE
Renaming data_proc_consent to job_consent

### DIFF
--- a/app/controllers/leads_controller.rb
+++ b/app/controllers/leads_controller.rb
@@ -12,6 +12,6 @@ class LeadsController < ApiController
   end
 
   def leads_params
-    params.require(:lead).permit(:name, :email, [interests: []], :data_proc_consent)
+    params.require(:lead).permit(:name, :email, [interests: []], :job_consent)
   end
 end

--- a/db/migrate/20220818090133_rename_data_proc_consent.rb
+++ b/db/migrate/20220818090133_rename_data_proc_consent.rb
@@ -1,0 +1,5 @@
+class RenameDataProcConsent < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :leads, :data_proc_consent, :job_consent
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_17_101644) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_18_090133) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,7 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_17_101644) do
   create_table "leads", force: :cascade do |t|
     t.string "name"
     t.string "email"
-    t.boolean "data_proc_consent", default: false
+    t.boolean "job_consent", default: false
     t.boolean "delivered", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/frontend/src/pages/SignupPage/index.js
+++ b/frontend/src/pages/SignupPage/index.js
@@ -141,7 +141,7 @@ const SignupPage = () => {
           name: state.name,
           email: state.email,
           interests: state.selectedInterests,
-          data_proc_consent: state.consent,
+          job_consent: state.consent,
         },
       }),
     })


### PR DESCRIPTION
Why:
* Its purpose wasn't clear for non developers working with active admin

How:
* By introducing a migration to rename the column itself
* By fixing the post request on the frontend
* By updating the params in controller