### PR TITLE
fix copy and spacing between links in social page

### DIFF
--- a/frontend/src/pages/SocialPage/index.js
+++ b/frontend/src/pages/SocialPage/index.js
@@ -35,7 +35,7 @@ const SocialPage = () => {
         </div>
 
         <div className={styles.bodyWrapper}>
-          <Heading3>Find us on our social media:</Heading3>
+          <Heading3>Connect with us on our social media:</Heading3>
         </div>
 
         <ul className={styles.linkWrapper}>

--- a/frontend/src/pages/SocialPage/index.module.css
+++ b/frontend/src/pages/SocialPage/index.module.css
@@ -23,7 +23,7 @@
 
 .linkWrapper {
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
   padding: 0;
   margin: 0;
 }
@@ -31,6 +31,7 @@
 .link {
   width: 32px;
   height: 32px;
+  margin: 0 10px;
   list-style-type: none;
 }
 


### PR DESCRIPTION
Why:
* Copy has changed on Figma;
* Links were placed too far apart from eachother.

How:
* Edit copy;
* Edit side margin the `.link` class