### PR TITLE
Close random access to /wheel and /win-prize

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,8 @@
 import { Routes, Route } from "react-router-dom";
 
+import ValidateEmail from "components/ValidateEmail";
+import ValidatePrize from "components/ValidatePrize";
+
 import HomePage from "pages/HomePage";
 import PrizePage from "pages/PrizePage";
 import SignupPage from "pages/SignupPage";
@@ -13,9 +16,23 @@ function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/signup" element={<SignupPage />} />
-        <Route path="/wheel" element={<WheelPage />} />
+        <Route
+          path="/wheel"
+          element={
+            <ValidateEmail>
+              <WheelPage />
+            </ValidateEmail>
+          }
+        />
         <Route path="/social-network" element={<SocialPage />} />
-        <Route path="/win-prize" element={<PrizePage />} />
+        <Route
+          path="/win-prize"
+          element={
+            <ValidatePrize>
+              <PrizePage />
+            </ValidatePrize>
+          }
+        />
         <Route path="/admin" element={<AdminPage />} />
       </Routes>
     </>

--- a/frontend/src/components/ValidateEmail/index.js
+++ b/frontend/src/components/ValidateEmail/index.js
@@ -1,0 +1,24 @@
+import { PropTypes } from "prop-types";
+import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+
+const ValidatePrize = ({ children }) => {
+  const navigator = useNavigate();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (localStorage.getItem("userData")) {
+      setLoading(true);
+    } else {
+      navigator("/");
+    }
+  }, [navigator]);
+
+  return loading ? children : null;
+};
+
+ValidatePrize.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default ValidatePrize;

--- a/frontend/src/components/ValidatePrize/index.js
+++ b/frontend/src/components/ValidatePrize/index.js
@@ -1,0 +1,24 @@
+import { PropTypes } from "prop-types";
+import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+
+const ValidatePrize = ({ children }) => {
+  const navigator = useNavigate();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (localStorage.getItem("prizeWon")) {
+      setLoading(true);
+    } else {
+      navigator("/");
+    }
+  }, [navigator]);
+
+  return loading ? children : null;
+};
+
+ValidatePrize.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default ValidatePrize;


### PR DESCRIPTION
Why: 
* The user shouldn't be able to access these pages if he doesn't do the flow correctly because he'll have blank error screens

How:
* Redirecting the user back to the home screen with useEffect hook that validates if the local storage suggests the user has played
* Doing this in two components, one for the Wheel (checks if the email exists) and one for the prize (checks if the user has won a prize)