### PR TITLE
Add terms and conditions customization through active admin

### DIFF
--- a/app/admin/terms_and_conditions.rb
+++ b/app/admin/terms_and_conditions.rb
@@ -1,0 +1,6 @@
+ActiveAdmin.register TermsAndCondition do
+
+  actions :index, :show, :edit, :update
+
+  permit_params :link
+end

--- a/app/admin/terms_and_conditions.rb
+++ b/app/admin/terms_and_conditions.rb
@@ -1,5 +1,6 @@
-ActiveAdmin.register TermsAndCondition do
+# frozen_string_literal: true
 
+ActiveAdmin.register TermsAndCondition do
   actions :index, :show, :edit, :update
 
   permit_params :link

--- a/app/controllers/terms_and_conditions_controller.rb
+++ b/app/controllers/terms_and_conditions_controller.rb
@@ -3,6 +3,10 @@
 # Controller that manages terms and conditions
 class TermsAndConditionsController < ApiController
   def index
+    render json: TermsAndCondition.all
+  end
+
+  def show
     render json: TermsAndCondition.find(1).slice(:link)
   end
 end

--- a/app/controllers/terms_and_conditions_controller.rb
+++ b/app/controllers/terms_and_conditions_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Controller that manages terms and conditions
+class TermsAndConditionsController < ApiController
+    def index
+      render json: TermsAndCondition.find(1).slice(:link)
+    end
+end

--- a/app/controllers/terms_and_conditions_controller.rb
+++ b/app/controllers/terms_and_conditions_controller.rb
@@ -2,7 +2,7 @@
 
 # Controller that manages terms and conditions
 class TermsAndConditionsController < ApiController
-    def index
-      render json: TermsAndCondition.find(1).slice(:link)
-    end
+  def index
+    render json: TermsAndCondition.find(1).slice(:link)
+  end
 end

--- a/app/models/terms_and_condition.rb
+++ b/app/models/terms_and_condition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TermsAndCondition < ApplicationRecord
-    validates :link, presence: true
+  validates :link, presence: true
 end

--- a/app/models/terms_and_condition.rb
+++ b/app/models/terms_and_condition.rb
@@ -1,0 +1,3 @@
+class TermsAndCondition < ApplicationRecord
+    validates :link, presence: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
   get '/leads', to: 'leads#index'
   post '/leads', to: 'leads#create'
   get '/emails', to: 'emails#index'
+  get '/terms', to: 'terms_and_conditions#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   get '/leads', to: 'leads#index'
   post '/leads', to: 'leads#create'
   get '/emails', to: 'emails#index'
-  get '/terms', to: 'terms_and_conditions#index'
+  get '/terms', to: 'terms_and_conditions#show'
 end

--- a/db/migrate/20220818183908_create_terms_and_conditions.rb
+++ b/db/migrate/20220818183908_create_terms_and_conditions.rb
@@ -1,0 +1,9 @@
+class CreateTermsAndConditions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :terms_and_conditions do |t|
+      t.string :link
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_18_090133) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_18_183908) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -86,6 +86,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_18_090133) do
     t.datetime "updated_at", null: false
     t.bigint "company_id"
     t.index ["company_id"], name: "index_socials_on_company_id"
+  end
+
+  create_table "terms_and_conditions", force: :cascade do |t|
+    t.string "link"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "leads", "prizes"

--- a/frontend/src/components/Forms/PolicyForm/index.js
+++ b/frontend/src/components/Forms/PolicyForm/index.js
@@ -3,10 +3,27 @@ import Heading1 from "components/Typography/Heading1";
 
 import { PropTypes } from "prop-types";
 import { TERMS, JOBS } from "pages/SignupPage";
+import { useEffect, useState } from "react";
 
 import styles from "./index.module.scss";
 
 const PolicyForm = ({ handleChange, validatesChecked }) => {
+  const [terms, setTerms] = useState("");
+
+  useEffect(() => {
+    fetch(`${process.env.REACT_APP_BACKEND_PATH}/terms`)
+      .then((response) => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          throw response;
+        }
+      })
+      .then((data) => {
+        setTerms(data.link);
+      });
+  }, []);
+
   return (
     <div className={styles.root}>
       <div className={styles.headingWrapper}>
@@ -21,7 +38,7 @@ const PolicyForm = ({ handleChange, validatesChecked }) => {
             onChange={handleChange(TERMS)}
           >
             &nbsp;
-            <a href="https://www.google.com" target="_blank" rel="noreferrer">
+            <a href={terms} target="_blank" rel="noreferrer">
               Terms and Conditions*
             </a>
           </Checkbox>


### PR DESCRIPTION
Why: 
* We want the admin to be able to customize the terms and conditions link, used in the privacy policy page

How:
* By creating a model and migration for the terms and conditions, containing a link
* By generating the active admin resource and removing the create possibility (we want the admin to just re-edit the same one)
* By fixing the front-end to fetch this link from the database