### PR TITLE
Stop creating new Lead entries with the same email

### DIFF
--- a/app/controllers/leads_controller.rb
+++ b/app/controllers/leads_controller.rb
@@ -7,8 +7,13 @@ class LeadsController < ApiController
   end
 
   def create
-    lead = Lead.create(leads_params)
-    render json: lead
+    lead = Lead.find_by(email: leads_params[:email])
+    if lead
+      lead.update(leads_params)
+    else
+      lead = Lead.create(leads_params)
+      render json: lead
+    end
   end
 
   def leads_params


### PR DESCRIPTION
Why:
* Instead of creating new entries with the same email, update the existing one with the new informations.
* This won't change the prize attributed and won't allow them to play again if they already have
* Allows the user to edit information they might have gotten wrong or changed their mind about

How:
* By updating the controller to check if the email exists -> if it does, update the existing entry, otherwise create a new one