### PR TITLE
Fix bug of always setting selected companies to false when adding

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -13,6 +13,6 @@ class Company < ApplicationRecord
   private
 
   def ensure_only_one_selected
-    self.class.update_all(selected: false)
+    self.class.update_all(selected: false) if selected
   end
 end


### PR DESCRIPTION
Why:
* Without the condition, if the admin adds a company but doesn't want it to be selected, it will still mark every other company as non selected, making it as no company is selected anymore

How:
* By validating if the admin is selecting the company being added