### PR TITLE
Fix delete company foreign key dependency

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -2,4 +2,11 @@
 
 ActiveAdmin.register Company do
   permit_params :name, :website, :selected
+
+  controller do
+    def destroy
+      Social.where(company_id: params[:id]).destroy_all
+      super
+    end
+  end
 end


### PR DESCRIPTION
Why:
* It wasn't possible to delete a company if it has socials associated because of the foreign key

How:
* By removing the socials in the active admin controller before removing the company