### PR TITLE
Switch to createRoot

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,12 +1,13 @@
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import "./index.css";
 import App from "./App";
 
-ReactDOM.render(
+const root = createRoot(document.getElementById("root"));
+
+root.render(
   <BrowserRouter>
     <App />
-  </BrowserRouter>,
-  document.getElementById("root")
+  </BrowserRouter>
 );


### PR DESCRIPTION
Why:

We were using `ReactDOM.render` which is no longer supported in React 18. Hence we were getting the following console error message `Until you switch to the new API, your app will behave as if it’s running React 17. Learn more: https://reactjs.org/link/switch-to-createroot`

How:

Use `createRoot`