### PR TITLE
Remove comments and dashboard and make companies the default page

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -3,6 +3,17 @@
 ActiveAdmin.register Company do
   permit_params :name, :website, :selected
 
+  index do
+    selectable_column
+    id_column
+    column :name
+    column :website
+    column :selected
+    column :created_at
+    column :updated_at
+    actions
+  end
+
   controller do
     def destroy
       Social.where(company_id: params[:id]).destroy_all

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register_page 'Dashboard' do
-  menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
+  menu false
 
   content title: proc { I18n.t('active_admin.dashboard') } do
     div class: 'blank_slate_container', id: 'dashboard_default_message' do

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -117,14 +117,14 @@ ActiveAdmin.setup do |config|
   # roots for each namespace.
   #
   # Default:
-  # config.root_to = 'dashboard#index'
+  config.root_to = 'companies#index'
 
   # == Admin Comments
   #
   # This allows your users to comment on any resource registered with Active Admin.
   #
   # You can completely disable comments:
-  # config.comments = false
+  config.comments = false
   #
   # You can change the name under which comments are registered:
   # config.comments_registration_name = 'AdminComment'
@@ -134,7 +134,7 @@ ActiveAdmin.setup do |config|
   # config.comments_order = 'created_at ASC'
   #
   # You can disable the menu item for the comments index page:
-  # config.comments_menu = false
+  config.comments_menu = false
   #
   # You can customize the comment menu:
   # config.comments_menu = { parent: 'Admin', priority: 1 }


### PR DESCRIPTION
Why:
* Comments and dashboard were useless
* Without a dashboard, there needs to be another default page

How:
* By setting config.comments and config.comments_menu to false
* By creating a companies#index that can be the new default page
* By changing config.root_to to companies#index
* By setting menu false to remove the dashboard