### PR TITLE
Refactor social page

### DIFF
--- a/frontend/src/components/Forms/PolicyForm/index.module.scss
+++ b/frontend/src/components/Forms/PolicyForm/index.module.scss
@@ -9,5 +9,6 @@
 
 .form {
   display: grid;
-  grid-gap: 40px;
+  grid-template-rows: repeat(2, auto);
+  grid-gap: 32px;
 }

--- a/frontend/src/components/LayoutWithBackground/index.module.scss
+++ b/frontend/src/components/LayoutWithBackground/index.module.scss
@@ -22,3 +22,10 @@
     left: unset;
   }
 }
+
+.svgWrapperBottomLeft {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  display: flex;
+}

--- a/frontend/src/pages/SocialPage/index.js
+++ b/frontend/src/pages/SocialPage/index.js
@@ -38,28 +38,15 @@ const SocialPage = () => {
   return (
     <LayoutWithBackground isInvertedTop={true}>
       <div className={styles.main}>
-        <div className={styles.headingWrapper}>
-          <Heading>Thanks for playing!</Heading>
-        </div>
-
-        <div className={styles.bodyWrapper}>
-          <Heading level={3}>Find us on our social media:</Heading>
-        </div>
-
-        <ul className={styles.linkWrapper}>
+        <Heading>Thanks for playing!</Heading>
+        <Heading level={3}>Find us on our social media:</Heading>
+        <ul className={styles.links}>
           {Object.keys(LOGOS).map((channel) => {
-            if (socials[channel]) {
-              return (
-                <li className={styles.link} key={channel}>
-                  <SocialMediaLink
-                    url={socials[channel]}
-                    logo={LOGOS[channel]}
-                  />
-                </li>
-              );
-            } else {
-              return null;
-            }
+            return (
+              <li className={styles.link} key={channel}>
+                <SocialMediaLink url={socials[channel]} logo={LOGOS[channel]} />
+              </li>
+            );
           })}
         </ul>
       </div>

--- a/frontend/src/pages/SocialPage/index.module.css
+++ b/frontend/src/pages/SocialPage/index.module.css
@@ -1,23 +1,17 @@
 .main {
   z-index: 1;
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
+  display: grid;
+  grid-template-rows: repeat(3, auto);
+  grid-gap: 32px;
+  align-items: center;
+  justify-content: center;
   padding: 0 var(--main-container-spacing);
 }
 
-.headingWrapper {
-  margin-bottom: 32px;
-  text-align: center;
-}
-
-.bodyWrapper {
-  margin-bottom: 32px;
-  text-align: center;
-}
-
-.linkWrapper {
-  display: flex;
+.links {
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: 20px;
   justify-content: center;
   padding: 0;
   margin: 0;
@@ -26,6 +20,5 @@
 .link {
   width: 32px;
   height: 32px;
-  margin: 0 10px;
   list-style-type: none;
 }


### PR DESCRIPTION
Why:

- We are using lots of wrappers for layout purposes. While not bad perse, it can be refactored.

How:

- By making the `main` element a `grid`

Notes:

- Once you refactor more pages, you might find that you can ideally create another Layout component to handle this. I doubt that would happen in this case because the social page is quite particular. But you can perhaps see how once you start removing the wrappers, some patterns appear. 