### PR TITLE
Refactor LayoutWithBackground

### DIFF
--- a/frontend/src/components/LayoutWithBackground/index.js
+++ b/frontend/src/components/LayoutWithBackground/index.js
@@ -1,23 +1,39 @@
 import { PropTypes } from "prop-types";
 
 import MainContainer from "components/MainContainer";
+import { ReactComponent as WheelImageBottomLeft } from "assets/svgs/wheel-background/bottom-left-landing.svg";
+import { ReactComponent as WheelImageBottomRight } from "assets/svgs/wheel-background/bottom-right.svg";
 import { ReactComponent as WheelImageTopLeft } from "assets/svgs/wheel-background/top-left.svg";
 import { ReactComponent as WheelImageTopRight } from "assets/svgs/wheel-background/top-right.svg";
 
 import styles from "./index.module.scss";
 import classNames from "classnames";
 
-const LayoutWithBackground = ({ children, isInverted }) => {
-  const svgClassName = classNames(styles.svgWrapper, {
-    [styles.svgWrapperTopRight]: isInverted,
+const LayoutWithBackground = ({
+  children,
+  isInvertedTop,
+  isInvertedBottom,
+}) => {
+  const svgTopClassName = classNames(styles.svgWrapperTop, {
+    [styles.topRight]: isInvertedTop,
+  });
+  const svgBottomClassName = classNames(styles.svgWrapperBottom, {
+    [styles.bottomRight]: isInvertedBottom,
   });
 
   return (
     <MainContainer hasGradient={true}>
-      <div className={svgClassName}>
-        {isInverted ? <WheelImageTopRight /> : <WheelImageTopLeft />}
+      <div className={svgTopClassName}>
+        {isInvertedTop ? <WheelImageTopRight /> : <WheelImageTopLeft />}
       </div>
       {children}
+      <div className={svgBottomClassName}>
+        {isInvertedBottom ? (
+          <WheelImageBottomRight />
+        ) : (
+          <WheelImageBottomLeft />
+        )}
+      </div>
     </MainContainer>
   );
 };
@@ -25,10 +41,12 @@ const LayoutWithBackground = ({ children, isInverted }) => {
 export default LayoutWithBackground;
 
 LayoutWithBackground.defaultProps = {
-  isInverted: false,
+  isInvertedTop: false,
+  isInvertedBottom: false,
 };
 
 LayoutWithBackground.propTypes = {
   children: PropTypes.node.isRequired,
-  isInverted: PropTypes.bool,
+  isInvertedTop: PropTypes.bool,
+  isInvertedBottom: PropTypes.bool,
 };

--- a/frontend/src/components/LayoutWithBackground/index.module.scss
+++ b/frontend/src/components/LayoutWithBackground/index.module.scss
@@ -1,12 +1,24 @@
-.svgWrapper {
+.svgWrapperTop {
   display: flex;
   justify-content: flex-start;
 
   > svg {
     max-width: 330px;
   }
+
+  &.topRight {
+    justify-content: flex-end;
+  }
 }
 
-.svgWrapperTopRight {
-  justify-content: flex-end;
+.svgWrapperBottom {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  display: flex;
+
+  &.bottomRight {
+    right: 0;
+    left: unset;
+  }
 }

--- a/frontend/src/pages/HomePage/index.js
+++ b/frontend/src/pages/HomePage/index.js
@@ -1,34 +1,25 @@
 import Logo from "components/Logo";
 import Button from "components/Button";
 import Heading from "components/Typography/Heading";
-import { ReactComponent as WheelImageBottomLeft } from "assets/svgs/wheel-background/bottom-left-landing.svg";
 import LayoutWithBackground from "components/LayoutWithBackground";
 
 import styles from "./index.module.css";
 
 const HomePage = () => {
   return (
-    <LayoutWithBackground isInverted={true}>
-      <div className={styles.main}>
-        <div>
+    <LayoutWithBackground isInvertedTop={true}>
+      <div className={styles.root}>
+        <div className={styles.main}>
           <div className={styles.logoWrapper}>
             <Logo />
           </div>
-
           <div className={styles.headingWrapper}>
             <Heading level={2}>
               Register to play and<br></br> win a prize!
             </Heading>
           </div>
-
-          <div className={styles.svgWrapperBottom}>
-            <WheelImageBottomLeft />
-          </div>
         </div>
-
-        <div className={styles.buttonWrapper}>
-          <Button href="/signup">Next</Button>
-        </div>
+        <Button href="/signup">Next</Button>
       </div>
     </LayoutWithBackground>
   );

--- a/frontend/src/pages/HomePage/index.module.css
+++ b/frontend/src/pages/HomePage/index.module.css
@@ -1,9 +1,15 @@
-.main {
+.root {
+  z-index: 1;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  align-items: center;
   justify-content: space-between;
-  padding: 0 var(--main-container-spacing);
+  padding: 0 var(--main-container-spacing) 60px;
+}
+
+.main {
+  flex-grow: 1;
 }
 
 .logoWrapper {
@@ -15,19 +21,4 @@
   margin-bottom: 20px;
   text-align: center;
   white-space: pre-line;
-}
-
-.svgWrapperBottom {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  display: flex;
-}
-
-.buttonWrapper {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  justify-content: center;
-  margin-bottom: 60px;
 }

--- a/frontend/src/pages/PrizePage/index.js
+++ b/frontend/src/pages/PrizePage/index.js
@@ -3,38 +3,23 @@ import Body from "components/Typography/Body";
 import Button from "components/Button";
 import LayoutWithBackground from "components/LayoutWithBackground";
 
-import { ReactComponent as WheelImageBottomRight } from "assets/svgs/wheel-background/bottom-right.svg";
-
 import styles from "./index.module.css";
 
 const PrizePage = () => {
   const prize = JSON.parse(localStorage.getItem("prizeWon"));
 
   return (
-    <LayoutWithBackground>
-      <div className={styles.main}>
-        <div className={styles.titleWrapper}>
+    <LayoutWithBackground isInvertedBottom={true}>
+      <div className={styles.root}>
+        <div className={styles.main}>
           <Heading>Congratulations!</Heading>
-        </div>
-
-        <div className={styles.headingWrapper}>
           <Heading level={2}>You won: {prize.name}</Heading>
-        </div>
-
-        <div className={styles.bodyWrapper}>
           <Body>
             {prize.type === "NFT"
               ? "Check your email to confirm and claim your prize."
               : "Check your email to claim your prize."}
           </Body>
         </div>
-      </div>
-
-      <div className={styles.svgWrapper}>
-        <WheelImageBottomRight />
-      </div>
-
-      <div className={styles.buttonWrapper}>
         <Button href="/social">Finish</Button>
       </div>
     </LayoutWithBackground>

--- a/frontend/src/pages/PrizePage/index.module.css
+++ b/frontend/src/pages/PrizePage/index.module.css
@@ -1,37 +1,16 @@
-.main {
+.root {
   z-index: 1;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  padding: 0 var(--main-container-spacing);
-}
-
-.titleWrapper {
-  margin-bottom: 32px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--main-container-spacing) 60px;
   text-align: center;
 }
 
-.headingWrapper {
-  margin-bottom: 32px;
-  text-align: center;
-}
-
-.bodyWrapper {
-  text-align: center;
-}
-
-.svgWrapper {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  z-index: 0;
-  display: flex;
-}
-
-.buttonWrapper {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  justify-content: center;
-  margin-bottom: 60px;
+.main {
+  display: grid;
+  grid-auto-flow: row;
+  grid-gap: 32px;
 }

--- a/frontend/src/pages/SocialPage/index.js
+++ b/frontend/src/pages/SocialPage/index.js
@@ -2,7 +2,6 @@ import { ReactComponent as FacebookLogo } from "assets/svgs/social/facebook.svg"
 import { ReactComponent as InstagramLogo } from "assets/svgs/social/instagram.svg";
 import { ReactComponent as LinkedinLogo } from "assets/svgs/social/linkedin.svg";
 import { ReactComponent as TwitterLogo } from "assets/svgs/social/twitter.svg";
-import { ReactComponent as WheelImageBottomLeft } from "assets/svgs/wheel-background/bottom-left-social.svg";
 
 import { useEffect, useState } from "react";
 
@@ -37,7 +36,7 @@ const SocialPage = () => {
   }, []);
 
   return (
-    <LayoutWithBackground isInverted={true}>
+    <LayoutWithBackground isInvertedTop={true}>
       <div className={styles.main}>
         <div className={styles.headingWrapper}>
           <Heading>Thanks for playing!</Heading>
@@ -63,10 +62,6 @@ const SocialPage = () => {
             }
           })}
         </ul>
-      </div>
-
-      <div className={styles.svgWrapper}>
-        <WheelImageBottomLeft />
       </div>
     </LayoutWithBackground>
   );

--- a/frontend/src/pages/SocialPage/index.module.css
+++ b/frontend/src/pages/SocialPage/index.module.css
@@ -29,10 +29,3 @@
   margin: 0 10px;
   list-style-type: none;
 }
-
-.svgWrapper {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  display: flex;
-}


### PR DESCRIPTION
Why:

- We were placing the bottom SVGs in multiple pages
- We were also using many wrappers for layout purposes


How:

- Move SVGs into `LayoutWithBackground` - Adding one more prop `isInvertedBottom`
- Use `grid` when possible
- Move spacings into Layout components