### PR TITLE
Refactor layouts

### DIFF
--- a/frontend/src/components/Wheel/index.js
+++ b/frontend/src/components/Wheel/index.js
@@ -38,27 +38,21 @@ const Wheel = ({ email }) => {
   }
 
   return (
-    <>
-      <div className={styles.main}>
-        <div className={styles.wheel}>
-          <div className={styles.wheelBackground}>
-            <WheelImageBackground />
-          </div>
-
-          <div
-            className={classNames(styles.prizesCircle, {
-              [styles.isRotating]: isRotating,
-            })}
-          >
-            <WheelImagePrizes width="100%" height="100%" />
-          </div>
-
-          <div className={styles.playButton}>
-            <WheelSpinButton width="100%" height="100%" onClick={startRotate} />
-          </div>
-        </div>
+    <div className={styles.wheel}>
+      <div className={styles.wheelBackground}>
+        <WheelImageBackground />
       </div>
-    </>
+      <div
+        className={classNames(styles.prizesCircle, {
+          [styles.isRotating]: isRotating,
+        })}
+      >
+        <WheelImagePrizes width="100%" height="100%" />
+      </div>
+      <div className={styles.playButton}>
+        <WheelSpinButton width="100%" height="100%" onClick={startRotate} />
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/components/Wheel/index.module.css
+++ b/frontend/src/components/Wheel/index.module.css
@@ -1,13 +1,5 @@
-.main {
-  display: flex;
-  align-items: center;
-  min-height: 100vh;
-  padding: 0 var(--main-container-spacing);
-}
-
 .wheel {
   position: relative;
-  flex: 1;
   max-height: 100%;
   aspect-ratio: 1 / 1;
 }

--- a/frontend/src/pages/HomePage/index.js
+++ b/frontend/src/pages/HomePage/index.js
@@ -1,14 +1,19 @@
 import Logo from "components/Logo";
 import Button from "components/Button";
 import Heading from "components/Typography/Heading";
-import LayoutWithBackground from "components/LayoutWithBackground";
+
+import { ReactComponent as WheelImageBottomLeft } from "assets/svgs/wheel-background/bottom-left-landing.svg";
+import { ReactComponent as WheelImageTopRight } from "assets/svgs/wheel-background/top-right.svg";
 
 import styles from "./index.module.css";
 
 const HomePage = () => {
   return (
-    <LayoutWithBackground isInvertedTop={true}>
-      <div className={styles.root}>
+    <div className={styles.root}>
+      <div className={styles.wheelTop}>
+        <WheelImageTopRight />
+      </div>
+      <div className={styles.container}>
         <div className={styles.main}>
           <div className={styles.logoWrapper}>
             <Logo />
@@ -21,7 +26,10 @@ const HomePage = () => {
         </div>
         <Button href="/signup">Next</Button>
       </div>
-    </LayoutWithBackground>
+      <div className={styles.wheelBottom}>
+        <WheelImageBottomLeft />
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/pages/HomePage/index.module.css
+++ b/frontend/src/pages/HomePage/index.module.css
@@ -1,10 +1,17 @@
 .root {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(var(--color-light-pink), var(--color-white));
+}
+
+.container {
   z-index: 1;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   align-items: center;
-  justify-content: space-between;
   padding: 0 var(--main-container-spacing) 60px;
 }
 
@@ -21,4 +28,25 @@
   margin-bottom: 20px;
   text-align: center;
   white-space: pre-line;
+}
+
+.wheelTop {
+  display: flex;
+  justify-content: flex-end;
+
+  > svg {
+    max-width: 330px;
+  }
+}
+
+.wheelBottom {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: flex-start;
+
+  > svg {
+    max-width: 330px;
+  }
 }

--- a/frontend/src/pages/PrizePage/index.js
+++ b/frontend/src/pages/PrizePage/index.js
@@ -1,7 +1,8 @@
 import Heading from "components/Typography/Heading";
 import Body from "components/Typography/Body";
 import Button from "components/Button";
-import LayoutWithBackground from "components/LayoutWithBackground";
+import { ReactComponent as WheelImageBottomLeft } from "assets/svgs/wheel-background/bottom-left-landing.svg";
+import { ReactComponent as WheelImageTopRight } from "assets/svgs/wheel-background/top-right.svg";
 
 import styles from "./index.module.css";
 
@@ -9,20 +10,28 @@ const PrizePage = () => {
   const prize = JSON.parse(localStorage.getItem("prizeWon"));
 
   return (
-    <LayoutWithBackground isInvertedBottom={true}>
-      <div className={styles.root}>
+    <div className={styles.root}>
+      <div className={styles.wheelTop}>
+        <WheelImageTopRight />
+      </div>
+      <div className={styles.container}>
         <div className={styles.main}>
-          <Heading>Congratulations!</Heading>
-          <Heading level={2}>You won: {prize.name}</Heading>
-          <Body>
-            {prize.type === "NFT"
-              ? "Check your email to confirm and claim your prize."
-              : "Check your email to claim your prize."}
-          </Body>
+          <div className={styles.content}>
+            <Heading>Congratulations!</Heading>
+            <Heading level={2}>You won: {prize.name}</Heading>
+            <Body>
+              {prize.type === "NFT"
+                ? "Check your email to confirm and claim your prize."
+                : "Check your email to claim your prize."}
+            </Body>
+          </div>
         </div>
         <Button href="/social">Finish</Button>
       </div>
-    </LayoutWithBackground>
+      <div className={styles.wheelBottom}>
+        <WheelImageBottomLeft />
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/pages/PrizePage/index.module.css
+++ b/frontend/src/pages/PrizePage/index.module.css
@@ -1,16 +1,48 @@
 .root {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(var(--color-light-pink), var(--color-white));
+}
+
+.container {
   z-index: 1;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   align-items: center;
-  justify-content: space-between;
   padding: 0 var(--main-container-spacing) 60px;
-  text-align: center;
 }
 
 .main {
+  flex-grow: 1;
+}
+
+.content {
   display: grid;
   grid-auto-flow: row;
   grid-gap: 32px;
+  justify-items: center;
+}
+
+.wheelTop {
+  display: flex;
+  justify-content: flex-end;
+
+  > svg {
+    max-width: 330px;
+  }
+}
+
+.wheelBottom {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: flex-start;
+
+  > svg {
+    max-width: 330px;
+  }
 }

--- a/frontend/src/pages/SignupPage/index.js
+++ b/frontend/src/pages/SignupPage/index.js
@@ -266,20 +266,22 @@ const SignupPage = () => {
   });
 
   return (
-    <MainContainer>
+    <div className={styles.root}>
       <div className={headerClassName}>
         <BackLink handleGoBack={returnToPrevStep} />
       </div>
-      <div className={styles.main}>{stepInfo[state.step].component}</div>
-      <div className={styles.buttonWrapper}>
-        <Button isDisabled={isDisabled} onClick={buttonHandler}>
-          {stepInfo[state.step].buttonText}
-        </Button>
+      <div className={styles.container}>
+        <div className={styles.main}>{stepInfo[state.step].component}</div>
+        <div className={styles.footer}>
+          <Button isDisabled={isDisabled} onClick={buttonHandler}>
+            {stepInfo[state.step].buttonText}
+          </Button>
+          <div className={styles.progressBarWrapper}>
+            {stepInfo[state.step].progressBar}
+          </div>
+        </div>
       </div>
-      <div className={styles.progressBarWrapper}>
-        {stepInfo[state.step].progressBar}
-      </div>
-    </MainContainer>
+    </div>
   );
 };
 

--- a/frontend/src/pages/SignupPage/index.module.scss
+++ b/frontend/src/pages/SignupPage/index.module.scss
@@ -1,3 +1,12 @@
+.root {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: 24px var(--main-container-spacing) 60px;
+  background: var(--color-white);
+}
+
 .header {
   margin-bottom: 44px;
 
@@ -6,21 +15,25 @@
   }
 }
 
-.main {
+.container {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  align-items: center;
-  margin-bottom: 32px;
+  // padding: 24px var(--main-container-spacing) 60px;
 }
 
-.buttonWrapper {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 32px;
+.main {
+  flex-grow: 1;
+  margin-bottom: 12px;
+}
+
+.footer {
+  text-align: center;
 }
 
 .progressBarWrapper {
-  display: flex;
-  justify-content: center;
+  position: absolute;
+  bottom: 28px;
+  left: 50%;
+  transform: translateX(-50%);
 }

--- a/frontend/src/pages/SocialPage/index.js
+++ b/frontend/src/pages/SocialPage/index.js
@@ -3,10 +3,12 @@ import { ReactComponent as InstagramLogo } from "assets/svgs/social/instagram.sv
 import { ReactComponent as LinkedinLogo } from "assets/svgs/social/linkedin.svg";
 import { ReactComponent as TwitterLogo } from "assets/svgs/social/twitter.svg";
 
+import { ReactComponent as WheelImageBottomLeft } from "assets/svgs/wheel-background/bottom-left-landing.svg";
+import { ReactComponent as WheelImageTopRight } from "assets/svgs/wheel-background/top-right.svg";
+
 import { useEffect, useState } from "react";
 
 import Heading from "components/Typography/Heading";
-import LayoutWithBackground from "components/LayoutWithBackground";
 import SocialMediaLink from "components/SocialMediaLink";
 
 import styles from "./index.module.css";
@@ -36,34 +38,42 @@ const SocialPage = () => {
   }, []);
 
   return (
-    <LayoutWithBackground isInvertedTop={true}>
-      <div className={styles.main}>
-        <div className={styles.headingWrapper}>
-          <Heading>Thanks for playing!</Heading>
-        </div>
-
-        <div className={styles.bodyWrapper}>
-          <Heading level={3}>Find us on our social media:</Heading>
-        </div>
-
-        <ul className={styles.linkWrapper}>
-          {Object.keys(LOGOS).map((channel) => {
-            if (socials[channel]) {
-              return (
-                <li className={styles.link} key={channel}>
-                  <SocialMediaLink
-                    url={socials[channel]}
-                    logo={LOGOS[channel]}
-                  />
-                </li>
-              );
-            } else {
-              return null;
-            }
-          })}
-        </ul>
+    <div className={styles.root}>
+      <div className={styles.wheelTop}>
+        <WheelImageTopRight />
       </div>
-    </LayoutWithBackground>
+      <div className={styles.container}>
+        <div className={styles.main}>
+          <div className={styles.content}>
+            <div className={styles.headingWrapper}>
+              <Heading>Thanks for playing!</Heading>
+            </div>
+            <div className={styles.bodyWrapper}>
+              <Heading level={3}>Find us on our social media:</Heading>
+            </div>
+            <ul className={styles.linkWrapper}>
+              {Object.keys(LOGOS).map((channel) => {
+                if (socials[channel]) {
+                  return (
+                    <li className={styles.link} key={channel}>
+                      <SocialMediaLink
+                        url={socials[channel]}
+                        logo={LOGOS[channel]}
+                      />
+                    </li>
+                  );
+                } else {
+                  return null;
+                }
+              })}
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div className={styles.wheelBottom}>
+        <WheelImageBottomLeft />
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/pages/SocialPage/index.module.css
+++ b/frontend/src/pages/SocialPage/index.module.css
@@ -1,9 +1,28 @@
-.main {
+.root {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(var(--color-light-pink), var(--color-white));
+}
+
+.container {
   z-index: 1;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  padding: 0 var(--main-container-spacing);
+  align-items: center;
+  padding: 0 var(--main-container-spacing) 60px;
+}
+
+.main {
+  flex-grow: 1;
+}
+
+.content {
+  display: grid;
+  grid-auto-flow: row;
+  grid-gap: 32px;
 }
 
 .headingWrapper {
@@ -28,4 +47,25 @@
   height: 32px;
   margin: 0 10px;
   list-style-type: none;
+}
+
+.wheelTop {
+  display: flex;
+  justify-content: flex-end;
+
+  > svg {
+    max-width: 330px;
+  }
+}
+
+.wheelBottom {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: flex-start;
+
+  > svg {
+    max-width: 330px;
+  }
 }

--- a/frontend/src/pages/WheelPage/index.js
+++ b/frontend/src/pages/WheelPage/index.js
@@ -1,13 +1,14 @@
-import MainContainer from "components/MainContainer";
 import Wheel from "components/Wheel";
+
+import styles from "./index.module.css";
 
 const WheelPage = () => {
   const { email } = JSON.parse(localStorage.getItem("userData"));
 
   return (
-    <MainContainer hasGradient={true}>
+    <div className={styles.root}>
       <Wheel email={email} />
-    </MainContainer>
+    </div>
   );
 };
 

--- a/frontend/src/pages/WheelPage/index.module.css
+++ b/frontend/src/pages/WheelPage/index.module.css
@@ -1,0 +1,8 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 0 var(--main-container-spacing);
+  background: linear-gradient(var(--color-light-pink), var(--color-white));
+}


### PR DESCRIPTION
Hey Campers! :sunny: This is just for fun. And in case you’re interested, though, I can perfectly understand your attention span is over now ... @jreis13 and I were trying to refactor the layouts, but it became super hazy quick with all the different props, containers, gradients etc. 

So, in this case, what I did is to put all the custom styles directly on the pages (instead of using `MainContainer` and `LayoutWithBackground`.

Now, it's much clearer what code is repeated and we could actually extract it into a few layouts. Again, not something to do right now, a day before launch. But just wanted to share how I'd do it. If I still have time, I might extract it so you have a complete overview.

🚀